### PR TITLE
Feature: InfoBoxes for FB page link and constituency

### DIFF
--- a/global.R
+++ b/global.R
@@ -23,6 +23,10 @@ library(DT)
 ## Read data from Google Sheets 4
 sheet_url <- "https://docs.google.com/spreadsheets/d/1usk9Q-5lA4bL_z6KXpUohc_2x_KhDgLxtm-YEtim_yk/"
 
+# put gsheets into de-authorised state
+# so no need to provide personal token
+gs4_deauth()
+
 data_master_raw <-
   googlesheets4::read_sheet(ss = sheet_url,
                             sheet = "Master")

--- a/global.R
+++ b/global.R
@@ -29,4 +29,7 @@ gs4_deauth()
 
 data_master_raw <-
   googlesheets4::read_sheet(ss = sheet_url,
-                            sheet = "Master")
+                            sheet = "Master",
+                            na = c("N/A", "")) %>% 
+  # flag indicating if FB link exists
+  mutate(exists_fb = if_else(condition = !is.na(x = facebook), "blue", "black"))

--- a/global.R
+++ b/global.R
@@ -31,5 +31,5 @@ data_master_raw <-
   googlesheets4::read_sheet(ss = sheet_url,
                             sheet = "Master",
                             na = c("N/A", "")) %>% 
-  # flag indicating if FB link exists
+  # infoBox colour indicating if FB link exists
   mutate(exists_fb = if_else(condition = !is.na(x = facebook), "blue", "black"))

--- a/server.R
+++ b/server.R
@@ -23,7 +23,17 @@ server <- function(input, output, session) {
   
   # ----- TAB: Data Explorer ----- #
   
-
+  # ValueBox: Party (English) -----------------------------------------------
+  output$infobox_fb <- renderInfoBox(
+    expr = {
+      infoBox(value = react_data_constituency()$DC_ZN,
+              icon = icon(name = "vote-yea"),
+              color = "purple",
+              href = react_data_constituency()$facebook,
+              title = "Click this box to visit the DC's FB page")
+    }
+  )
+  
   # ValueBox: Party (English) -----------------------------------------------
   output$valuebox_party_en <- renderValueBox(
     expr = {

--- a/server.R
+++ b/server.R
@@ -15,7 +15,7 @@ server <- function(input, output, session) {
   react_data_constituency <- reactive(
     x = {
       data_select <- filter(.data = data_master_raw, 
-                            Constituency_EN == input$input_consituency_en)
+                            DropDownText == input$input_dropdowntext)
       
       return(data_select)
     }
@@ -26,7 +26,7 @@ server <- function(input, output, session) {
   # ValueBox: Party (English) -----------------------------------------------
   output$infobox_fb <- renderInfoBox(
     expr = {
-      infoBox(value = react_data_constituency()$DC_ZN,
+      infoBox(value = react_data_constituency()$DC_EN,
               icon = icon(name = "facebook-square"),
               color = "blue",
               href = react_data_constituency()$facebook,

--- a/server.R
+++ b/server.R
@@ -35,7 +35,8 @@ server <- function(input, output, session) {
                        title = "區議員名稱 / DC's name",
                        subtitle = "按此格到區議員的面書專頁 / Click this box to visit their FB page."),
           title = "If it does not re-direct to their FB page, this means their FB page does not exist or we could not find it.",
-          trigger = "hover"
+          trigger = "hover",
+          placement = "right"
         ) #tipify
       ) #div
     }
@@ -53,7 +54,8 @@ server <- function(input, output, session) {
                        color = "red",
                        fill = TRUE),
           title = "This is the political party that the DC belongs to", 
-          trigger = "hover"
+          trigger = "hover",
+          placement = "bottom"
         ) #tipify
       ) #div
     }
@@ -71,7 +73,8 @@ server <- function(input, output, session) {
                        color = "red",
                        fill = TRUE),
           title = "This is the constituency the DC belongs to", 
-          trigger = "hover"
+          trigger = "hover",
+          placement = "bottom"
         ) #tipify
       ) #div
     }

--- a/server.R
+++ b/server.R
@@ -26,7 +26,7 @@ server <- function(input, output, session) {
   # ValueBox: Party (English) -----------------------------------------------
   output$infobox_fb <- renderInfoBox(
     expr = {
-      infoBox(value = react_data_constituency()$DC_EN,
+      infoBox(value = paste0(react_data_constituency()$DC_ZH, " / ", react_data_constituency()$DC_EN),
               icon = icon(name = "facebook-square"),
               color = "blue",
               href = react_data_constituency()$facebook,
@@ -39,8 +39,9 @@ server <- function(input, output, session) {
     expr = {
       tags$div(
         tipify(
-          el = infoBox(value = react_data_constituency()$Party_EN,
-                       title = "Affiliated party (English)",
+          el = infoBox(value = react_data_constituency()$Party_ZH,
+                       title = "(Placeholder Chinese text) / Affiliated party",
+                       subtitle = react_data_constituency()$Party_EN,
                        icon = icon(name = "vote-yea"),
                        color = "red",
                        fill = TRUE),
@@ -56,8 +57,9 @@ server <- function(input, output, session) {
     expr = {
       tags$div(
         tipify(
-          el = infoBox(value = react_data_constituency()$Constituency_EN,
-                       title = "Constituency (English)",
+          el = infoBox(value = react_data_constituency()$Constituency_ZH,
+                       title = "(Placeholder Chinese text) / Constituency (English)",
+                       subtitle = react_data_constituency()$Constituency_EN,
                        icon = icon(name = "map-signs"),
                        color = "red",
                        fill = TRUE),

--- a/server.R
+++ b/server.R
@@ -12,7 +12,7 @@ server <- function(input, output, session) {
   # ----- REACTIVES ----- #
   
   # filter data according to user selected option
-  react_data_constituency <- reactive(
+  react_data_dropdown <- reactive(
     x = {
       data_select <- filter(.data = data_master_raw, 
                             DropDownText == input$input_dropdowntext)
@@ -26,11 +26,18 @@ server <- function(input, output, session) {
   # ValueBox: Party (English) -----------------------------------------------
   output$infobox_fb <- renderInfoBox(
     expr = {
-      infoBox(value = paste0(react_data_constituency()$DC_ZH, " / ", react_data_constituency()$DC_EN),
-              icon = icon(name = "facebook-square"),
-              color = "blue",
-              href = react_data_constituency()$facebook,
-              title = "Click this box to visit the DC's FB page")
+      tags$div(
+        tipify(
+          el = infoBox(value = paste0(react_data_dropdown()$DC_ZH, " / ", react_data_dropdown()$DC_EN),
+                       icon = icon(name = "facebook-square"),
+                       color = react_data_dropdown()$exists_fb,
+                       href = react_data_dropdown()$facebook,
+                       title = "區議員名稱 / DC's name",
+                       subtitle = "按此格到區議員的面書專頁 / Click this box to visit their FB page."),
+          title = "If it does not re-direct to their FB page, this means their FB page does not exist or we could not find it.",
+          trigger = "hover"
+        ) #tipify
+      ) #div
     }
   )
   
@@ -39,9 +46,9 @@ server <- function(input, output, session) {
     expr = {
       tags$div(
         tipify(
-          el = infoBox(value = react_data_constituency()$Party_ZH,
-                       title = "(Placeholder Chinese text) / Affiliated party",
-                       subtitle = react_data_constituency()$Party_EN,
+          el = infoBox(value = react_data_dropdown()$Party_ZH,
+                       title = "黨派 / Affiliated party",
+                       subtitle = react_data_dropdown()$Party_EN,
                        icon = icon(name = "vote-yea"),
                        color = "red",
                        fill = TRUE),
@@ -57,9 +64,9 @@ server <- function(input, output, session) {
     expr = {
       tags$div(
         tipify(
-          el = infoBox(value = react_data_constituency()$Constituency_ZH,
-                       title = "(Placeholder Chinese text) / Constituency (English)",
-                       subtitle = react_data_constituency()$Constituency_EN,
+          el = infoBox(value = react_data_dropdown()$Constituency_ZH,
+                       title = "選區 / Constituency",
+                       subtitle = react_data_dropdown()$Constituency_EN,
                        icon = icon(name = "map-signs"),
                        color = "red",
                        fill = TRUE),

--- a/server.R
+++ b/server.R
@@ -35,15 +35,16 @@ server <- function(input, output, session) {
   )
   
   # ValueBox: Party (English) -----------------------------------------------
-  output$valuebox_party_en <- renderValueBox(
+  output$infobox_party_en <- renderInfoBox(
     expr = {
       tags$div(
         tipify(
-          el = valueBox(value = react_data_constituency()$Party_EN,
-                        subtitle = "Affiliated party (English)",
-                        icon = icon(name = "vote-yea"),
-                        color = "maroon"),
-          title = "This is the political party that the constituency's DC belongs to", 
+          el = infoBox(value = react_data_constituency()$Party_EN,
+                       title = "Affiliated party (English)",
+                       icon = icon(name = "vote-yea"),
+                       color = "red",
+                       fill = TRUE),
+          title = "This is the political party that the DC belongs to", 
           trigger = "hover"
         ) #tipify
       ) #div
@@ -55,10 +56,11 @@ server <- function(input, output, session) {
     expr = {
       tags$div(
         tipify(
-          el = valueBox(value = react_data_constituency()$Constituency_EN,
-                        subtitle = "Constituency (English)",
-                        icon = icon(name = "map-signs"),
-                        color = "maroon"),
+          el = infoBox(value = react_data_constituency()$Constituency_EN,
+                       title = "Constituency (English)",
+                       icon = icon(name = "map-signs"),
+                       color = "red",
+                       fill = TRUE),
           title = "This is the constituency the DC belongs to", 
           trigger = "hover"
         ) #tipify

--- a/server.R
+++ b/server.R
@@ -37,7 +37,7 @@ server <- function(input, output, session) {
                        width = 12),
           title = "If it does not re-direct to their FB page, this means their FB page does not exist or we could not find it.",
           trigger = "hover",
-          placement = "right"
+          placement = "left"
         ) #tipify
       ) #div
     }

--- a/server.R
+++ b/server.R
@@ -40,7 +40,20 @@ server <- function(input, output, session) {
     }
   )
 
-
-  
+  # InfoBox: Constituency (English) -----------------------------------------
+  output$infobox_constituency_en <- renderInfoBox(
+    expr = {
+      tags$div(
+        tipify(
+          el = valueBox(value = react_data_constituency()$Constituency_EN,
+                        subtitle = "Constituency (English)",
+                        icon = icon(name = "map-signs"),
+                        color = "maroon"),
+          title = "This is the constituency the DC belongs to", 
+          trigger = "hover"
+        ) #tipify
+      ) #div
+    }
+  )
   
 }

--- a/server.R
+++ b/server.R
@@ -33,7 +33,8 @@ server <- function(input, output, session) {
                        color = react_data_dropdown()$exists_fb,
                        href = react_data_dropdown()$facebook,
                        title = "區議員名稱 / DC's name",
-                       subtitle = "按此格到區議員的面書專頁 / Click this box to visit their FB page."),
+                       subtitle = "按此格到區議員的面書專頁 / Click this box to visit their FB page.",
+                       width = 12),
           title = "If it does not re-direct to their FB page, this means their FB page does not exist or we could not find it.",
           trigger = "hover",
           placement = "right"
@@ -52,7 +53,8 @@ server <- function(input, output, session) {
                        subtitle = react_data_dropdown()$Party_EN,
                        icon = icon(name = "vote-yea"),
                        color = "red",
-                       fill = TRUE),
+                       fill = TRUE,
+                       width = 6),
           title = "This is the political party that the DC belongs to", 
           trigger = "hover",
           placement = "bottom"
@@ -71,7 +73,8 @@ server <- function(input, output, session) {
                        subtitle = react_data_dropdown()$Constituency_EN,
                        icon = icon(name = "map-signs"),
                        color = "red",
-                       fill = TRUE),
+                       fill = TRUE,
+                       width = 6),
           title = "This is the constituency the DC belongs to", 
           trigger = "hover",
           placement = "bottom"

--- a/server.R
+++ b/server.R
@@ -27,8 +27,8 @@ server <- function(input, output, session) {
   output$infobox_fb <- renderInfoBox(
     expr = {
       infoBox(value = react_data_constituency()$DC_ZN,
-              icon = icon(name = "vote-yea"),
-              color = "purple",
+              icon = icon(name = "facebook-square"),
+              color = "blue",
               href = react_data_constituency()$facebook,
               title = "Click this box to visit the DC's FB page")
     }

--- a/ui.R
+++ b/ui.R
@@ -13,7 +13,7 @@ ui <- dashboardPage(
   
   # Header
   header = dashboardHeader(
-    title = "Hong Kong: District Councillors"
+    title = "HK: District Councillors"
   ),
   
   # Sidebar
@@ -31,17 +31,17 @@ ui <- dashboardPage(
       
       # DCs list tab
       menuItem(
+        text = "Overview of a DC",
+        icon = icon(name = "search"),
+        tabName = "tab_dcoverview"
+      ),
+      
+      # DCs list tab
+      menuItem(
         text = "List of DCs",
         icon = icon(name = "list-ul"),
         tabName = "tab_dclist"
       ),
-      
-      # DC updates tab
-      menuItem(
-        text = "FB updates of DC",
-        icon = icon(name = "window-maximize"),
-        tabName = "tab_dcupdate"
-      )
       
     ) # sidebarMenu
   ), #dashboardSidebar
@@ -121,10 +121,10 @@ ui <- dashboardPage(
       ), #tabItem
       
       
-      # Tab: Data Explorer ----------------------------------------------------------
+      # Tab: DC Overview ----------------------------------------------------------
       
       tabItem(
-        tabName = "tab_dclist",
+        tabName = "tab_dcoverview",
         selectInput(inputId = "input_dropdowntext",
                     label = "Please choose a district",
                     choices = sort(unique(data_master_raw$DropDownText))),
@@ -141,10 +141,10 @@ ui <- dashboardPage(
       ), #tabItem
       
       
-      # Tab: MI Report -------------------------------------------------------
+      # Tab: DC List -------------------------------------------------------
       
       tabItem(
-        tabName = "tab_dcupdate"
+        tabName = "tab_dclist"
         
       ) #tabItem
       

--- a/ui.R
+++ b/ui.R
@@ -136,7 +136,8 @@ ui <- dashboardPage(
           width = 12,
           
           fluidRow(
-            valueBoxOutput(outputId = "valuebox_party_en", width = NULL)
+            valueBoxOutput(outputId = "valuebox_party_en", width = NULL),
+            infoBoxOutput(outputId = "infobox_constituency_en", width = NULL)
           )
         )
       ), #tabItem

--- a/ui.R
+++ b/ui.R
@@ -129,18 +129,15 @@ ui <- dashboardPage(
                     label = "Please choose a district",
                     choices = sort(unique(data_master_raw$DropDownText))),
         
-        column(
-          width = 12,
-          
-          fluidRow(
-            infoBoxOutput(outputId = "infobox_fb", width = NULL)
-          ),
-          
-          fluidRow(
-            infoBoxOutput(outputId = "infobox_party_en", width = NULL),
-            infoBoxOutput(outputId = "infobox_constituency_en", width = NULL)
-          )
-        ) #column
+
+        fluidRow(
+          infoBoxOutput(outputId = "infobox_fb", width = NULL)
+        ),
+        
+        fluidRow(
+          infoBoxOutput(outputId = "infobox_party_en", width = NULL),
+          infoBoxOutput(outputId = "infobox_constituency_en", width = NULL)
+        )
       ), #tabItem
       
       

--- a/ui.R
+++ b/ui.R
@@ -136,6 +136,7 @@ ui <- dashboardPage(
           width = 12,
           
           fluidRow(
+            infoBoxOutput(outputId = "infobox_fb", width = NULL),
             valueBoxOutput(outputId = "valuebox_party_en", width = NULL),
             infoBoxOutput(outputId = "infobox_constituency_en", width = NULL)
           )

--- a/ui.R
+++ b/ui.R
@@ -125,12 +125,9 @@ ui <- dashboardPage(
       
       tabItem(
         tabName = "tab_dclist",
-        selectInput(inputId = "input_consituency_en",
-                    label = "Please choose a constituency",
-                    choices = sort(unique(data_master_raw$Constituency_EN))),
-        selectInput(inputId = "input_constituency_zh",
-                    label = "Please choose a constituency",
-                    choices = sort(unique(data_master_raw$Constituency_ZH))),
+        selectInput(inputId = "input_dropdowntext",
+                    label = "Please choose a district",
+                    choices = sort(unique(data_master_raw$DropDownText))),
         
         column(
           width = 12,

--- a/ui.R
+++ b/ui.R
@@ -137,10 +137,10 @@ ui <- dashboardPage(
           ),
           
           fluidRow(
-            valueBoxOutput(outputId = "valuebox_party_en", width = NULL),
+            infoBoxOutput(outputId = "infobox_party_en", width = NULL),
             infoBoxOutput(outputId = "infobox_constituency_en", width = NULL)
           )
-        )
+        ) #column
       ), #tabItem
       
       

--- a/ui.R
+++ b/ui.R
@@ -136,7 +136,10 @@ ui <- dashboardPage(
           width = 12,
           
           fluidRow(
-            infoBoxOutput(outputId = "infobox_fb", width = NULL),
+            infoBoxOutput(outputId = "infobox_fb", width = NULL)
+          ),
+          
+          fluidRow(
             valueBoxOutput(outputId = "valuebox_party_en", width = NULL),
             infoBoxOutput(outputId = "infobox_constituency_en", width = NULL)
           )

--- a/ui.R
+++ b/ui.R
@@ -41,7 +41,7 @@ ui <- dashboardPage(
         text = "List of DCs",
         icon = icon(name = "list-ul"),
         tabName = "tab_dclist"
-      ),
+      )
       
     ) # sidebarMenu
   ), #dashboardSidebar


### PR DESCRIPTION
# Summary
This branch creates `infoBox` objects for displaying the constituency (probably obsolete since it is what the user chose!) and the link to the DC who is in charge of the constituency. 

Specifically, the second `infoBox` has an embedded link.

![image](https://user-images.githubusercontent.com/25527485/87874655-66e04180-c9c3-11ea-9b53-0e3f1ffdae81.png)


# Changes
The changes made in this PR are:
1. `infoBox` on constituency
1. `infoBox` on DC name plus link to their FB page.
...

# Check
- [x] The app can be deployed.
- [x] The `infoBox` for FB link redirects you to their FB page.
- [x] The CI/CD travis.ci and R CMD checks pass. 
- [x] The FB logo changes to black when no link is available.
...

# Note
The redirect to FB page functionality does not always work. This may be because the DC's FB page may not exist, so there is no web link being returned.
