### PR TITLE
Feature: Add Facebook iframe to app

### DIFF
--- a/.development/googlesheets_dataclean.R
+++ b/.development/googlesheets_dataclean.R
@@ -59,7 +59,7 @@ master_sheet <-
 
 # add iframe to master sheet ----------------------------------------------
 chunk1 <- '<iframe src="https://www.facebook.com/plugins/page.php?href='
-chunk3 <- '&tabs=timeline&width=340&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true&appId=3131730406906292" width="340" height="500" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>'
+chunk3 <- '&tabs=timeline&width=340&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true&appId=3131730406906292" width="500" height="500" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>'
 
 master_sheet <-
   master_sheet %>%

--- a/.development/googlesheets_dataclean.R
+++ b/.development/googlesheets_dataclean.R
@@ -56,6 +56,15 @@ master_sheet <-
   left_join(dc_key, by = "Code") %>%
   select(-Code)
 
+
+# add iframe to master sheet ----------------------------------------------
+chunk1 <- '<iframe src="https://www.facebook.com/plugins/page.php?href='
+chunk3 <- '&tabs=timeline&width=340&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true&appId=3131730406906292" width="340" height="500" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>'
+
+master_sheet <-
+  master_sheet %>%
+  mutate(iframe = paste(chunk1, facebook, chunk3))
+
 # Write to sheet ----------------------------------------------------------
 googlesheets4::range_write(ss = sheet_url,
                            sheet = "Master",

--- a/server.R
+++ b/server.R
@@ -84,6 +84,10 @@ server <- function(input, output, session) {
     }
   )
   
+  # iframe  ---------------------------------------------
+  output$frame <- renderUI({
+    HTML(react_data_dropdown()$iframe)
+  })
   
   # ----- TAB: List of DCs ----- #
   

--- a/ui.R
+++ b/ui.R
@@ -153,6 +153,9 @@ ui <- dashboardPage(
         fluidRow(
           infoBoxOutput(outputId = "infobox_party_en", width = NULL),
           infoBoxOutput(outputId = "infobox_constituency_en", width = NULL)
+        ),
+        fluidRow(
+          uiOutput("frame") # iframe
         )
       ), #tabItem
       

--- a/ui.R
+++ b/ui.R
@@ -155,7 +155,10 @@ ui <- dashboardPage(
           infoBoxOutput(outputId = "infobox_constituency_en", width = NULL)
         ),
         fluidRow(
-          uiOutput("frame") # iframe
+          column(
+            width = 3,
+            uiOutput("frame") # iframe
+          )
         )
       ), #tabItem
       


### PR DESCRIPTION
# Summary
This branch creates an `iframe` column in the 'Master' sheet of the source Google spreadsheet, and loads an iframe within the Shiny app. 

# Changes
The changes made in this PR are:
1. Creates an `iframe` column in the 'Master' sheet of the source Google spreadsheet
1. Load the `iframe` of the Facebook page feed for the selected district councillor
...

# Check
- [x] All checks pass
- [x] The app deploys successfully
...

# (OPTIONAL) Note
This "fixes #<issue_number>"

*<other things, such as how to incorporate new changes>*
*<brief summary of the purpose of this pull request>*
