### PR TITLE
Feature: Leaflet map

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     googlesheets4,
     shinyBS,
     sf,
-    ggplot2
+    leaflet
 Suggests: 
     janitor,
     purrr,

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -63,15 +63,15 @@ data_master_raw <-
 # Map import --------------------------------------------------------------
 
 ## Pre-load/create map
-map_hk_districts <- leaflet(data = shape_district) %>% 
-  addProviderTiles(provider = providers$Wikimedia) %>% 
+map_hk_districts <- leaflet(data = st_as_sf(data_master_raw)) %>% 
+  addTiles() %>% 
   addPolygons(weight = 0.5, 
               fillOpacity = 0.3, 
               color = '#009E73',
               highlightOptions = highlightOptions(color = '#000000', 
                                                   weight = 2,
                                                   bringToFront = TRUE),
-              popup = shape_district$ENAME,
+              popup = data_master_raw$DropDownText,
               options = popupOptions(clickable = TRUE, closeOnClick = TRUE))
 
 

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -70,7 +70,9 @@ map_hk_districts <- leaflet(data = shape_district) %>%
               color = '#009E73',
               highlightOptions = highlightOptions(color = '#000000', 
                                                   weight = 2,
-                                                  bringToFront = TRUE))
+                                                  bringToFront = TRUE),
+              popup = shape_district$ENAME,
+              options = popupOptions(clickable = TRUE, closeOnClick = TRUE))
 
 
 # Typeform HTML -----------------------------------------------------------

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -37,17 +37,13 @@ plot_theme <- theme(plot.title = element_text(face = "bold", hjust = 0.5),
 sheet_url <- "https://docs.google.com/spreadsheets/d/1007RLMHSukSJ5OfCcDJdnJW5QMZyS2P-81fe7utCZwk/"
 path_data <- "extdata"
 path_shape_district <- paste0(path_data, "/" , "dcca_2019/DCCA_2019.shp")
-path_shape_hk <- paste0(path_data, "/", "gadm/gadm36_HKG_0.shp")
 
 
 # Data import -------------------------------------------------------------
 
 ## shapefiles
 shape_district <- st_read(dsn = path_shape_district)
-shape_hk <- st_read(dsn = path_shape_hk)
-
 shape_district <- st_transform(x = shape_district, crs = 4326)
-shape_hk <- st_transform(x = shape_hk, crs = 4326)
 
 ## gsheets
 data_master_raw <-

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -14,7 +14,7 @@ library(tidyr)
 library(googlesheets4)
 library(sf)
 
-library(ggplot2)
+library(leaflet)
 
 ## shiny-related
 library(shiny)
@@ -46,6 +46,9 @@ path_shape_hk <- paste0(path_data, "/", "gadm/gadm36_HKG_0.shp")
 shape_district <- st_read(dsn = path_shape_district)
 shape_hk <- st_read(dsn = path_shape_hk)
 
+shape_district <- st_transform(x = shape_district, crs = 4326)
+shape_hk <- st_transform(x = shape_hk, crs = 4326)
+
 ## gsheets
 data_master_raw <-
   googlesheets4::read_sheet(ss = sheet_url,
@@ -61,10 +64,14 @@ data_master_raw <-
 # Map import --------------------------------------------------------------
 
 ## Pre-load/create map
-map_hk_districts <- ggplot() +
-  geom_sf(data = shape_hk, fill = '#009E73') +
-  geom_sf(data = shape_district, fill = '#56B4E9', alpha = 0.2, linetype = 'dotted', size = 0.2) +
-  plot_theme
+map_hk_districts <- leaflet(data = shape_district) %>% 
+  addProviderTiles(provider = providers$Wikimedia) %>% 
+  addPolygons(weight = 0.5, 
+              fillOpacity = 0.3, 
+              color = '#56B4E9',
+              highlightOptions = highlightOptions(color = "#000000", 
+                                                  weight = 2,
+                                                  bringToFront = TRUE))
 
 
 # Typeform HTML -----------------------------------------------------------

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -70,7 +70,7 @@ map_hk_districts <- ggplot() +
 # Typeform HTML -----------------------------------------------------------
 html_typeform <- HTML(text = "<div class=\"typeform-widget\" 
                               data-url=\"https://form.typeform.com/to/gFHC02gE\" 
-                              style=\"width: 100%; height: 500px;\"></div> 
+                              style=\"width: 100%; height: 800px;\"></div> 
                               <script> (function() { var qs,
                                                     js,
                                                     q,

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -65,3 +65,34 @@ map_hk_districts <- ggplot() +
   geom_sf(data = shape_hk, fill = '#009E73') +
   geom_sf(data = shape_district, fill = '#56B4E9', alpha = 0.2, linetype = 'dotted', size = 0.2) +
   plot_theme
+
+
+# Typeform HTML -----------------------------------------------------------
+html_typeform <- HTML(text = "<div class=\"typeform-widget\" 
+                              data-url=\"https://form.typeform.com/to/gFHC02gE\" 
+                              style=\"width: 100%; height: 500px;\"></div> 
+                              <script> (function() { var qs,
+                                                    js,
+                                                    q,
+                                                    s,
+                                                    d=document, 
+                                                    gi=d.getElementById, 
+                                                    ce=d.createElement, 
+                                                    gt=d.getElementsByTagName, 
+                                                    id=\"typef_orm\", 
+                                                    b=\"https://embed.typeform.com/\"; 
+                                                      if(!gi.call(d,id)) { js=ce.call(d,\"script\"); 
+                                                      js.id=id; js.src=b+\"embed.js\"; 
+                                                      q=gt.call(d,\"script\")[0]; 
+                                                      q.parentNode.insertBefore(js,q) } }
+                                        )() </script> 
+                              <div style=\"font-family:Sans-Serif;
+                                            font-size:12px;
+                                            color: #999;
+                                            opacity: 0.5; 
+                                            padding-top: 5px;
+                                          \"> powered by 
+                                          <a href=\"https://admin.typeform.com/signup?utm_campaign=gFHC02gE&utm_source=typeform.com-01EENYCBWQACS4BQ2SV4V5D2C9-free&utm_medium=typeform&utm_content=typeform-embedded-poweredbytypeform&utm_term=EN\" 
+                                                  style=\"color: #999\" 
+                                                  target=\"_blank\">Typeform</a> </div>")
+

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -44,6 +44,9 @@ path_shape_district <- paste0(path_data, "/" , "dcca_2019/DCCA_2019.shp")
 ## shapefiles
 shape_district <- st_read(dsn = path_shape_district)
 shape_district <- st_transform(x = shape_district, crs = 4326)
+shape_district$centroids <- shape_district %>% 
+  st_centroid() %>% 
+  st_coordinates()
 
 ## gsheets
 data_master_raw <-

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -67,8 +67,8 @@ map_hk_districts <- leaflet(data = shape_district) %>%
   addProviderTiles(provider = providers$Wikimedia) %>% 
   addPolygons(weight = 0.5, 
               fillOpacity = 0.3, 
-              color = '#56B4E9',
-              highlightOptions = highlightOptions(color = "#000000", 
+              color = '#009E73',
+              highlightOptions = highlightOptions(color = '#000000', 
                                                   weight = 2,
                                                   bringToFront = TRUE))
 

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -25,14 +25,6 @@ library(DT)
 ## put gsheets into de-authorised state so no need for personal token for app
 gs4_deauth()
 
-## set theme for plots
-plot_theme <- theme(plot.title = element_text(face = "bold", hjust = 0.5),
-                    plot.subtitle = element_text(face = "bold", hjust = 0.5),
-                    panel.background = element_blank(),
-                    axis.line = element_blank(),
-                    axis.text = element_blank(),
-                    axis.ticks = element_blank())
-
 # Data file paths ---------------------------------------------------------
 sheet_url <- "https://docs.google.com/spreadsheets/d/1007RLMHSukSJ5OfCcDJdnJW5QMZyS2P-81fe7utCZwk/"
 path_data <- "extdata"

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -128,7 +128,11 @@ server <- function(input, output, session) {
         addPolygons(data = react_district_highlight(),
                     color = '#D55E00',
                     weight = 0.5,
-                    fillOpacity = 0.6)
+                    fillOpacity = 0.6) %>% 
+        # centre map on user-chosen district
+        setView(lng = react_district_highlight()$centroids[,"X"],
+                lat = react_district_highlight()$centroids[,"Y"], 
+                zoom = 11)
       
     }
   )

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -126,7 +126,8 @@ server <- function(input, output, session) {
       
       map_hk_districts %>% 
         addPolygons(data = react_district_highlight(),
-                    fill = '#D55E00',
+                    color = '#D55E00',
+                    weight = 0.5,
                     fillOpacity = 0.6)
       
     }

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -129,6 +129,9 @@ server <- function(input, output, session) {
                     color = '#D55E00',
                     weight = 0.5,
                     fillOpacity = 0.6) %>% 
+        addPopups(lng = react_district_highlight()$centroids[,"X"],
+                  lat = react_district_highlight()$centroids[,"Y"], 
+                  popup = react_district_highlight()$District) %>% 
         # centre map on user-chosen district
         setView(lng = react_district_highlight()$centroids[,"X"],
                 lat = react_district_highlight()$centroids[,"Y"], 

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -159,4 +159,15 @@ server <- function(input, output, session) {
     ) #list
   ) #renderDT
   
+  
+
+  # ----- TAB: Survey ----- #
+  
+  # TypeForm Survey ---------------------------------------------------------
+  output$html_typeform = renderUI(
+    expr = {
+      html_typeform
+    }
+  )
+  
 }

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -114,7 +114,7 @@ server <- function(input, output, session) {
   ) #renderInfoBox
   
 
-  # iframe  ---------------------------------------------
+  # RenderUI: FB Feed  ---------------------------------------------
   output$frame <- renderUI({
     HTML(react_data_dropdown()$iframe)
   })
@@ -133,14 +133,16 @@ server <- function(input, output, session) {
   
   # ----- TAB: List of DCs ----- #
   
-  # Data Table with DC Details  ---------------------------------------------
+  # RenderDT: DC Details  ---------------------------------------------
   
   output$dc_table = renderDT(
-    select(.data = data_master_raw,
-           Region,
-           District,
-           Constituency = DropDownText,
-           DC),
+    expr = {
+      select(.data = data_master_raw,
+             Region,
+             District,
+             Constituency = DropDownText,
+             DC)
+    }, #expr
     filter = "top",
     rownames = FALSE,
     options = list(lengthMenu = list(c(10, 20, -1),
@@ -157,8 +159,8 @@ server <- function(input, output, session) {
                      ) #list
                   ) #list
     ) #list
+
   ) #renderDT
-  
   
 
   # ----- TAB: Survey ----- #

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -121,11 +121,13 @@ server <- function(input, output, session) {
 
 
   # RenderPlot: Districts ---------------------------------------------------
-  output$plot_district <- renderPlot(
+  output$plot_district <- renderLeaflet(
     expr = {
       
-      map_hk_districts +
-        geom_sf(data = react_district_highlight(), fill = '#D55E00', alpha = 0.5)
+      map_hk_districts %>% 
+        addPolygons(data = react_district_highlight(),
+                    fill = '#D55E00',
+                    fillOpacity = 0.6)
       
     }
   )

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -131,7 +131,7 @@ server <- function(input, output, session) {
                     fillOpacity = 0.6) %>% 
         addPopups(lng = react_district_highlight()$centroids[,"X"],
                   lat = react_district_highlight()$centroids[,"Y"], 
-                  popup = react_district_highlight()$District) %>% 
+                  popup = react_district_highlight()$DropDownText) %>% 
         # centre map on user-chosen district
         setView(lng = react_district_highlight()$centroids[,"X"],
                 lat = react_district_highlight()$centroids[,"Y"], 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -50,14 +50,14 @@ ui <- dashboardPage(
       
       # Survey tab
       menuItem(
-       text = "Survey",
-       icon = icon(name = "table"),
+       text = "Complete our survey",
+       icon = icon(name = "edit"),
        tabName = "tab_survey"
       ),
       
       # Construction tab
       menuItem(
-        text = "Construction",
+        text = "How this was made",
         icon = icon(name = "info-circle"),
         tabName = "tab_construction"
       )

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -79,7 +79,7 @@ ui <- dashboardPage(
       tabItem(
         tabName = "tab_dcoverview",
         selectizeInput(inputId = "input_dropdowntext",
-                    label = "請選擇或輸入選區 / Please type or select a district",
+                    label = "請選擇或輸入選區 / Please type or select a constituency",
                     choices = sort(unique(data_master_raw$DropDownText))),
         
 

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -190,7 +190,6 @@ ui <- dashboardPage(
               tags$li(a(href = "https://docs.google.com/spreadsheets/d/1usk9Q-5lA4bL_z6KXpUohc_2x_KhDgLxtm-YEtim_yk/edit#gid=0", "Google Sheet of HK DCs")),
               tags$li(a(href = "https://en.wikipedia.org/wiki/2019_Hong_Kong_local_elections", "Wikipedia of HK DCs")),
               tags$li("Facebook pages of each HK DC"),
-              tags$li(a(href = "https://gadm.org/", "Shapefiles of HK")),
               tags$li(a(href = "https://accessinfo.hk/en/request/shapefileshp_for_2019_district_c", "Shapefiles of HK district councils"))
             )
           ), hr(),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -41,21 +41,21 @@ ui <- dashboardPage(
         tabName = "tab_dcoverview"
       ),
       
-      # DCs list tab
+      # List of DCs tab
       menuItem(
         text = "List of DCs",
         icon = icon(name = "list-ul"),
         tabName = "tab_dclist"
       ),
       
-      # TypeForm survey
+      # Survey tab
       menuItem(
        text = "Survey",
        icon = icon(name = "table"),
-       tabName = "tab_typeform"
+       tabName = "tab_survey"
       ),
       
-      # construction tab
+      # Construction tab
       menuItem(
         text = "Construction",
         icon = icon(name = "info-circle"),
@@ -116,19 +116,20 @@ ui <- dashboardPage(
         tabName = "tab_dclist",
         
         fluidPage(
-          DTOutput("dc_table")
+          DTOutput(outputId = "dc_table")
         ) #fluidPage
         
       ), #tabItem
       
       
-      # Tab: TypeForm -----------------------------------------------------
+      # Tab: Survey -----------------------------------------------------
       
       tabItem(
-        tabName = "tab_typeform",
+        tabName = "tab_survey",
+        
         fluidPage(
           htmlOutput(outputId = "html_typeform")
-        )
+        ) #fluidPage
       ), #tabItem
       
       

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -34,7 +34,7 @@ ui <- dashboardPage(
     sidebarMenu(
       id = "menu",
       
-      # DCs list tab
+      # Overview of a DC tab
       menuItem(
         text = "Overview of a DC",
         icon = icon(name = "user"),
@@ -48,12 +48,12 @@ ui <- dashboardPage(
         tabName = "tab_dclist"
       ),
       
-      # DCs list tab
-      #menuItem(
-      #  text = "Details",
-      #  icon = icon(name = "table"),
-      #  tabName = "tab_dctable"
-      #)
+      # TypeForm survey
+      menuItem(
+       text = "Survey",
+       icon = icon(name = "table"),
+       tabName = "tab_typeform"
+      ),
       
       # construction tab
       menuItem(
@@ -122,10 +122,20 @@ ui <- dashboardPage(
       ), #tabItem
       
       
-      # Tab: DC Appendix -----------------------------------------------------
+      # Tab: DC Table -----------------------------------------------------
       
       tabItem(
-        tabName = "tab_dctable"
+        tabName = "tab_dctable",
+        fluidPage(
+          HTML(text = "<div class=\"typeform-widget\" data-url=\"https://form.typeform.com/to/gFHC02gE\" style=\"width: 100%; height: 500px;\"></div> <script> (function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id=\"typef_orm\", b=\"https://embed.typeform.com/\"; if(!gi.call(d,id)) { js=ce.call(d,\"script\"); js.id=id; js.src=b+\"embed.js\"; q=gt.call(d,\"script\")[0]; q.parentNode.insertBefore(js,q) } })() </script> <div style=\"font-family: Sans-Serif;font-size: 12px;color: #999;opacity: 0.5; padding-top: 5px;\"> powered by <a href=\"https://admin.typeform.com/signup?utm_campaign=gFHC02gE&utm_source=typeform.com-01EENYCBWQACS4BQ2SV4V5D2C9-free&utm_medium=typeform&utm_content=typeform-embedded-poweredbytypeform&utm_term=EN\" style=\"color: #999\" target=\"_blank\">Typeform</a> </div>")
+        )
+      ), #tabItem
+      
+      
+      # Tab: TypeForm -----------------------------------------------------
+      
+      tabItem(
+        tabName = "tab_typeform"
         
       ), #tabItem
       

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -102,8 +102,8 @@ ui <- dashboardPage(
         
         fluidRow(
           box(
-            solidHeader = TRUE, status = "success", width = 9,
-            leafletOutput(outputId = "plot_district", width = NULL)
+            solidHeader = TRUE, status = "success",
+            leafletOutput(outputId = "plot_district", width = "100%")
           ) #box
         ) #fluidRow
         

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -103,7 +103,7 @@ ui <- dashboardPage(
         fluidRow(
           box(
             solidHeader = TRUE, status = "success", width = 9,
-            plotOutput(outputId = "plot_district", width = NULL)
+            leafletOutput(outputId = "plot_district", width = NULL)
           ) #box
         ) #fluidRow
         

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -122,21 +122,13 @@ ui <- dashboardPage(
       ), #tabItem
       
       
-      # Tab: DC Table -----------------------------------------------------
-      
-      tabItem(
-        tabName = "tab_dctable",
-        fluidPage(
-          HTML(text = "<div class=\"typeform-widget\" data-url=\"https://form.typeform.com/to/gFHC02gE\" style=\"width: 100%; height: 500px;\"></div> <script> (function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id=\"typef_orm\", b=\"https://embed.typeform.com/\"; if(!gi.call(d,id)) { js=ce.call(d,\"script\"); js.id=id; js.src=b+\"embed.js\"; q=gt.call(d,\"script\")[0]; q.parentNode.insertBefore(js,q) } })() </script> <div style=\"font-family: Sans-Serif;font-size: 12px;color: #999;opacity: 0.5; padding-top: 5px;\"> powered by <a href=\"https://admin.typeform.com/signup?utm_campaign=gFHC02gE&utm_source=typeform.com-01EENYCBWQACS4BQ2SV4V5D2C9-free&utm_medium=typeform&utm_content=typeform-embedded-poweredbytypeform&utm_term=EN\" style=\"color: #999\" target=\"_blank\">Typeform</a> </div>")
-        )
-      ), #tabItem
-      
-      
       # Tab: TypeForm -----------------------------------------------------
       
       tabItem(
-        tabName = "tab_typeform"
-        
+        tabName = "tab_typeform",
+        fluidPage(
+          htmlOutput(outputId = "html_typeform")
+        )
       ), #tabItem
       
       

--- a/renv.lock
+++ b/renv.lock
@@ -149,6 +149,13 @@
       "Repository": "CRAN",
       "Hash": "0f22be39ec1d141fd03683c06f3a6e67"
     },
+    "covr": {
+      "Package": "covr",
+      "Version": "3.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "cbc6df1ef6ee576f844f973c1fc04ab4"
+    },
     "crayon": {
       "Package": "crayon",
       "Version": "1.3.4",
@@ -282,6 +289,13 @@
       "Repository": "CRAN",
       "Hash": "36ed3c9b1f0bbcd574d2769b625f80fb"
     },
+    "gridExtra": {
+      "Package": "gridExtra",
+      "Version": "2.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7d7f283939f563670a697165b2cf5560"
+    },
     "gtable": {
       "Package": "gtable",
       "Version": "0.3.0",
@@ -373,6 +387,20 @@
       "Repository": "CRAN",
       "Hash": "d908914ae53b04d4c0c0fd72ecc35370"
     },
+    "leaflet": {
+      "Package": "leaflet",
+      "Version": "2.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3f3f5e5603fc791dfb77279ad84cc711"
+    },
+    "leaflet.providers": {
+      "Package": "leaflet.providers",
+      "Version": "1.9.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d3082a7beac4a1aeb96100ff06265d7e"
+    },
     "lifecycle": {
       "Package": "lifecycle",
       "Version": "0.2.0",
@@ -393,6 +421,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "1bb58822a20301cee84a41678e25d9b7"
+    },
+    "markdown": {
+      "Package": "markdown",
+      "Version": "1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "61e4a10781dd00d7d81dd06ca9b94e95"
     },
     "mgcv": {
       "Package": "mgcv",
@@ -464,6 +499,13 @@
       "Repository": "CRAN",
       "Hash": "b6b150cd4709e0c0c9b5d51ac4376282"
     },
+    "png": {
+      "Package": "png",
+      "Version": "0.1-7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "03b7076c234cb3331288919983326c55"
+    },
     "praise": {
       "Package": "praise",
       "Version": "1.0.0",
@@ -506,6 +548,13 @@
       "Repository": "CRAN",
       "Hash": "97def703420c8ab10d8f0e6c72101e02"
     },
+    "raster": {
+      "Package": "raster",
+      "Version": "3.3-13",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "51cfecf7b9518d46b119f92d581616b6"
+    },
     "rematch": {
       "Package": "rematch",
       "Version": "1.0.1",
@@ -526,6 +575,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "1c3ef87cbb81c23ac96797781ec7aecc"
+    },
+    "rex": {
+      "Package": "rex",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "093584b944440c5cd07a696b3c8e0e4c"
     },
     "rlang": {
       "Package": "rlang",
@@ -604,6 +660,13 @@
       "Repository": "CRAN",
       "Hash": "947e4e02a79effa5d512473e10f41797"
     },
+    "sp": {
+      "Package": "sp",
+      "Version": "1.4-2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3290eebc34ba4df5e213878d54c1e623"
+    },
     "stringi": {
       "Package": "stringi",
       "Version": "1.4.6",
@@ -681,6 +744,13 @@
       "Repository": "CRAN",
       "Hash": "1739235995f08583db4095a28c357207"
     },
+    "viridis": {
+      "Package": "viridis",
+      "Version": "0.5.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6f6b49e5b3b5ee5a6d0c28bf1b4b9eb3"
+    },
     "viridisLite": {
       "Package": "viridisLite",
       "Version": "0.3.0",
@@ -694,6 +764,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "ecd17882a0b4419545691e095b74ee89"
+    },
+    "xfun": {
+      "Package": "xfun",
+      "Version": "0.16",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b4106139b90981a8bfea9c10bab0baf1"
     },
     "xtable": {
       "Package": "xtable",


### PR DESCRIPTION
# Summary
This branch replaces the current static map with an interactive Leaflet map. This should allow users to find their constituency via selecting their region, though this is more of a roundabout way. 

Ideally, also want selection by region at the top of the tab too.

# Changes
The changes made in this PR are:
1. Replace gg-mapping with Leaflet mapping.
1. Sets the map view to centre on the constituency the user selected.
1. Show constituency when user clicks on an area on map.
1. Correct dropdown text to state constituency rather than district.

***

# Check
- [x] The Leaflet map is interactive.
- [x] The view of the map centres on what the user selects.
- [x] The website is not slow to load up nor use.
- [x] The travis.ci and R CMD checks pass.

***

## (OPTIONAL) Note
This "fixes #41"

## Error
There is an error if you choose Jardine's Lookout. This is because we do not have shape info or we cannot join shape info onto our dataframe going into the app. Will need to investigate further.
```
data_master_raw %>% filter(ConstituencyCode == 'B-08') %>% glimpse()
```
