### PR TITLE
Feature: Intro Interactive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,8 @@ Imports:
     googlesheets4,
     shinyBS,
     sf,
-    leaflet
+    leaflet,
+    rintrojs
 Suggests: 
     janitor,
     purrr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,9 @@ Imports:
     shinyBS,
     sf,
     leaflet,
-    rintrojs
+    rintrojs,
+    shinycssloaders,
+    shinyjs
 Suggests: 
     janitor,
     purrr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
     leaflet,
     rintrojs,
     shinycssloaders,
-    shinyjs
+    shinyjs,
+    shinyhelper
 Suggests: 
     janitor,
     purrr,

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ shiny::runApp(appDir = "inst/app.R")
 
 ## Data Source
 
-A list of the District Councillors and their Facebooks page hyperlinks are publicly-accessible on Google Drive [here](https://docs.google.com/spreadsheets/d/1usk9Q-5lA4bL_z6KXpUohc_2x_KhDgLxtm-YEtim_yk/edit#gid=0).
+A list of the District Councillors and their Facebooks page hyperlinks are publicly-accessible on Google Drive [here](https://docs.google.com/spreadsheets/d/1007RLMHSukSJ5OfCcDJdnJW5QMZyS2P-81fe7utCZwk/).
 
 ***
 
@@ -95,3 +95,6 @@ If you encounter a clear bug, please file an issue with a minimal reproducible e
 ## Code of Conduct
 
 Please note that the hkdistrictcouncillors project is released with a [Contributor Code of Conduct](https://github.com/avisionh/dashboard-hkdistrictcouncillors/blob/feature/code-coverage/CODE_OF_CONDUCT.md). By contributing to this project, you agree to abide by its terms.
+
+## Project Team website
+To find out more about our project team and other projects by us, please visit our [website](https://hong-kong-districts-info.github.io/).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The Shiny app is deployed onto shinyapps.io in the links below:
     │   └── app/               
     |       ├── extdata/                        <- Data for app
     |       ├── R/                              <- Functions for app
+    |       ├── www/                            <- Logo files for app
+    |       ├── helpfiles/                      <- Markdown of shinyhelper tips
     |       ├── google-analytics.html           <- Link app with Google Analytics
     |       ├── global.R                        <- Static objects for app
     |       ├── server.R                        <- Reactive objects for app

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -26,6 +26,10 @@ library(DT)
 library(rintrojs)
 library(shinycssloaders)
 
+# set spinner options
+options(spinner.color = "#009E73",
+        spinner.type = 8)
+
 ## put gsheets into de-authorised state so no need for personal token for app
 gs4_deauth()
 

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -24,6 +24,7 @@ library(shinydashboard)
 library(DT)
 
 library(rintrojs)
+library(shinycssloaders)
 
 ## put gsheets into de-authorised state so no need for personal token for app
 gs4_deauth()

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -24,6 +24,7 @@ library(shinydashboard)
 library(DT)
 
 library(rintrojs)
+library(shinyhelper)
 library(shinycssloaders)
 
 # set spinner options

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -22,6 +22,8 @@ library(shinyBS)
 library(shinydashboard)
 library(DT)
 
+library(rintrojs)
+
 ## put gsheets into de-authorised state so no need for personal token for app
 gs4_deauth()
 

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -19,6 +19,7 @@ library(leaflet)
 ## shiny-related
 library(shiny)
 library(shinyBS)
+library(shinyjs)
 library(shinydashboard)
 library(DT)
 

--- a/inst/app/helpfiles/dropdowntext.md
+++ b/inst/app/helpfiles/dropdowntext.md
@@ -1,0 +1,6 @@
+#### Tip: Dropdown
+
+You can either:
+
+1. select from the dropdown list, or 
+1. type the name of your constituency in here.

--- a/inst/app/helpfiles/infoboxfb.md
+++ b/inst/app/helpfiles/infoboxfb.md
@@ -1,0 +1,3 @@
+#### Tip: Facebook click-through
+
+Click on this to access their public FB page.

--- a/inst/app/helpfiles/plotdistrict.md
+++ b/inst/app/helpfiles/plotdistrict.md
@@ -1,0 +1,3 @@
+#### Tip: Map for searching own consituency
+
+You can also use this to find the name of your constituency by selecting your region on the map.

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -66,13 +66,6 @@ server <- function(input, output, session) {
               }
   ) #observeEvent
   
-  # open navigation sidebar, the sidebarMenu
-  observeEvent(eventExpr = input$button_navigation,
-               handlerExpr = {
-                 removeClass(selector = "body", class = "sidebar-collapse")
-               }
-  ) #observeEvent
-  
   
   # ----- TAB: Overview of a DC ----- #
   

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -55,11 +55,15 @@ server <- function(input, output, session) {
   
   # start introjs when button is pressed
   observeEvent(eventExpr = input$button_help,
-               handlerExpr = introjs(session = session,
-                                     options = list("nextLabel" = "Next step",
+               handlerExpr = {
+                 introjs(session = session,
+                         options = list("nextLabel" = "Next step",
                                                     "prevLabel" = "Go back",
                                                     "skipLabel" = "Close tutorial"),
-                                     events = list(onbeforechange = readCallback('switchTabs')))
+                         events = list(onbeforechange = readCallback('switchTabs')))
+                 # add class to minimise sidebar when going through tutorial - for mobile
+                 addClass(selector = "body", class = "sidebar-collapse")
+               }
                ) #observeEvent
   
   

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -8,28 +8,10 @@
 #       server.R must create a function called server, like below:
 
 server <- function(input, output, session) {
-  
-  # Password and T&Cs Pop-up Box ---------------------------------------------------------
-  
-  # show modalDialog on app start-up
-  showModal(modal())  
-  
-  # check cookie-consent and render UI if correct
-  observeEvent(
-    
-    eventExpr = input$submit_cookieconsent,
-    
-    handlerExpr = {
-      
-      # allows access to dashboard if consent, otherwise shutdown
-      if (input$button_cookieconsent == "(是) Yes, I accept tracking") {
-        removeModal()
-      } else {
-        stopApp()
-      }
-    }
-  )
 
+  # initiate hints 
+  hintjs(session = session)
+  
   # ----- REACTIVES ----- #
   
   # filter data according to user selected option
@@ -53,7 +35,30 @@ server <- function(input, output, session) {
   
   # ----- OBSERVE EVENTS ----- #
   
-  # start introjs when button is pressed
+  # Password and T&Cs Pop-up Box ---------------------------------------------------------
+  
+  # show modalDialog on app start-up
+  showModal(modal())  
+  
+  # check cookie-consent and render UI if correct
+  observeEvent(
+    
+    eventExpr = input$submit_cookieconsent,
+    
+    handlerExpr = {
+      
+      # allows access to dashboard if consent, otherwise shutdown
+      if (input$button_cookieconsent == "(是) Yes, I accept tracking") {
+        removeModal()
+      } else {
+        stopApp()
+      }
+    }
+  )
+
+  # Interactive Tutorial ----------------------------------------------------
+
+  # start introjs and hide sidebar when button is pressed
   observeEvent(eventExpr = input$button_help,
                handlerExpr = {
                  introjs(session = session,

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -64,62 +64,47 @@ server <- function(input, output, session) {
   
   # ----- TAB: Overview of a DC ----- #
   
-  # ValueBox: Party (English) -----------------------------------------------
+  # InfoBox: Party (English) -----------------------------------------------
   output$infobox_fb <- renderInfoBox(
     expr = {
       tags$div(
-        tipify(
-          el = infoBox(value = paste0(react_data_dropdown()$DC_ZH, " / ", react_data_dropdown()$DC_EN),
-                       icon = icon(name = "facebook-square"),
-                       color = react_data_dropdown()$exists_fb,
-                       href = react_data_dropdown()$facebook,
-                       title = "區議員名稱 / DC's name",
-                       subtitle = "按此格到區議員的面書專頁 / Click this box to visit their FB page.",
-                       width = 12),
-          title = "If it does not re-direct to their FB page, this means their FB page does not exist or we could not find it.",
-          trigger = "hover",
-          placement = "left"
-        ) #tipify
+        infoBox(value = paste0(react_data_dropdown()$DC_ZH, " / ", react_data_dropdown()$DC_EN),
+                icon = icon(name = "facebook-square"),
+                color = react_data_dropdown()$exists_fb,
+                href = react_data_dropdown()$facebook,
+                title = "區議員名稱 / DC's name",
+                subtitle = "按此格到區議員的面書專頁 / Click this box to visit their FB page.",
+                width = 12)
       ) #div
     }
   ) #renderInfoBox
   
-  # ValueBox: Party (English) -----------------------------------------------
-  output$infobox_party_en <- renderInfoBox(
+  # InfoBox: Party (English) -----------------------------------------------
+  output$infobox_party <- renderInfoBox(
     expr = {
       tags$div(
-        tipify(
-          el = infoBox(value = react_data_dropdown()$Party_ZH,
-                       title = "黨派 / Affiliated party",
-                       subtitle = react_data_dropdown()$Party_EN,
-                       icon = icon(name = "vote-yea"),
-                       color = "green",
-                       fill = TRUE,
-                       width = 6),
-          title = "This is the political party that the DC belongs to", 
-          trigger = "hover",
-          placement = "bottom"
-        ) #tipify
+        infoBox(value = react_data_dropdown()$Party_ZH,
+                title = "黨派 / Affiliated party",
+                subtitle = react_data_dropdown()$Party_EN,
+                icon = icon(name = "vote-yea"),
+                color = "green",
+                fill = TRUE,
+                width = 6)
       ) #div
     }
   ) #renderInfoBox
 
   # InfoBox: Constituency (English) -----------------------------------------
-  output$infobox_constituency_en <- renderInfoBox(
+  output$infobox_constituency <- renderInfoBox(
     expr = {
       tags$div(
-        tipify(
-          el = infoBox(value = react_data_dropdown()$Constituency_ZH,
-                       title = "選區 / Constituency",
-                       subtitle = react_data_dropdown()$Constituency_EN,
-                       icon = icon(name = "map-signs"),
-                       color = "green",
-                       fill = TRUE,
-                       width = 6),
-          title = "This is the constituency the DC belongs to", 
-          trigger = "hover",
-          placement = "bottom"
-        ) #tipify
+        infoBox(value = react_data_dropdown()$Constituency_ZH,
+                title = "選區 / Constituency",
+                subtitle = react_data_dropdown()$Constituency_EN,
+                icon = icon(name = "map-signs"),
+                color = "green",
+                fill = TRUE,
+                width = 6)
       ) #div
     }
   ) #renderInfoBox

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -58,7 +58,8 @@ server <- function(input, output, session) {
                handlerExpr = introjs(session = session,
                                      options = list("nextLabel" = "Next step",
                                                     "prevLabel" = "Go back",
-                                                    "skipLabel" = "Close tutorial"))
+                                                    "skipLabel" = "Close tutorial"),
+                                     events = list(onbeforechange = readCallback('switchTabs')))
                ) #observeEvent
   
   

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -51,6 +51,17 @@ server <- function(input, output, session) {
   )
   
   
+  # ----- OBSERVE EVENTS ----- #
+  
+  # start introjs when button is pressed
+  observeEvent(eventExpr = input$button_help,
+               handlerExpr = introjs(session = session,
+                                     options = list("nextLabel" = "Next step",
+                                                    "prevLabel" = "Go back",
+                                                    "skipLabel" = "Close tutorial"))
+               ) #observeEvent
+  
+  
   # ----- TAB: Overview of a DC ----- #
   
   # ValueBox: Party (English) -----------------------------------------------
@@ -180,6 +191,6 @@ server <- function(input, output, session) {
     expr = {
       html_typeform
     }
-  )
+  ) #renderUI
   
 }

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -11,6 +11,8 @@ server <- function(input, output, session) {
 
   # initiate hints 
   hintjs(session = session)
+  # intiate shinyhelper
+  observe_helpers()
   
   # ----- REACTIVES ----- #
   

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -58,13 +58,20 @@ server <- function(input, output, session) {
                handlerExpr = {
                  introjs(session = session,
                          options = list("nextLabel" = "Next step",
-                                                    "prevLabel" = "Go back",
-                                                    "skipLabel" = "Close tutorial"),
+                                        "prevLabel" = "Go back",
+                                        "skipLabel" = "Close tutorial"),
                          events = list(onbeforechange = readCallback('switchTabs')))
                  # add class to minimise sidebar when going through tutorial - for mobile
                  addClass(selector = "body", class = "sidebar-collapse")
+              }
+  ) #observeEvent
+  
+  # open navigation sidebar, the sidebarMenu
+  observeEvent(eventExpr = input$button_navigation,
+               handlerExpr = {
+                 removeClass(selector = "body", class = "sidebar-collapse")
                }
-               ) #observeEvent
+  ) #observeEvent
   
   
   # ----- TAB: Overview of a DC ----- #

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -36,6 +36,7 @@ ui <- dashboardPage(
   sidebar = dashboardSidebar(
     
     introjsUI(),
+    useShinyjs(),
     
     sidebarMenu(
       id = "menu",
@@ -62,17 +63,17 @@ ui <- dashboardPage(
        badgeColor = "green",
        tabName = "tab_survey"
       ),
-      
+    
       # Construction tab
       menuItem(
         text = "How this was made",
         icon = icon(name = "info-circle"),
         tabName = "tab_construction"
       ),
-      
+    
       # Tutorial button
       actionButton(inputId = "button_help", "Press for tutorial")
-      
+    
     ) # sidebarMenu
   ), #dashboardSidebar
   

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -95,6 +95,7 @@ ui <- dashboardPage(
           data.hint = "You can select from the dropdown or type."
         ), #introBox
         
+        # nested introBox
         introBox(
           
           introBox(
@@ -106,28 +107,42 @@ ui <- dashboardPage(
             data.hint = "Click on this to access their public FB page."
           ),
           
-          fluidRow(
-            infoBoxOutput(outputId = "infobox_party_en", width = NULL),
-            infoBoxOutput(outputId = "infobox_constituency_en", width = NULL)
+          introBox(
+            fluidRow(
+              infoBoxOutput(outputId = "infobox_party", width = NULL),
+              infoBoxOutput(outputId = "infobox_constituency", width = NULL)
+            ),
+            data.step = 4,
+            data.intro = "These show the party and consituency of the DC selected."
           ),
+          
           data.step = 2,
           data.intro = "These tiles provide basic information relating to the contituency selected."
+        
         ), #introBox
         
-        fluidRow(
-          column(
-            width = 3,
-            uiOutput("frame") # iframe
-          ) #column
-          
-        ), #fluidRow
+        introBox(
+          fluidRow(
+            column(
+              width = 3,
+              uiOutput("frame") # iframe
+            ) #column
+          ), #fluidRow
+          data.step = 5,
+          data.intro = "This shows the latest posts by the DC on their FB page."
+        ), #introBox
         
-        fluidRow(
-          box(
-            solidHeader = TRUE, status = "success",
-            leafletOutput(outputId = "plot_district", width = "100%")
-          ) #box
-        ) #fluidRow
+        introBox(
+          fluidRow(
+            box(
+              solidHeader = TRUE, status = "success",
+              leafletOutput(outputId = "plot_district", width = "100%")
+            ) #box
+          ), #fluidRow
+          data.step = 6,
+          data.intro = "This highlights the constituency boundaries, with your selected constituency being highlighted.",
+          data.hint = "You can also use this to find the name of your constituency by selecting your region on the map."
+        ) #introBox
         
       ), #tabItem
       

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -14,9 +14,6 @@ ui <- dashboardPage(
   # Header
   header = dashboardHeader(
     title = "HK: District Councillors",
-    tags$li(actionLink(inputId = "button_navigation",
-                       label = "Open navigation sidebar"),
-            class = "dropdown"),
     tags$li(actionLink(inputId = "button_help", 
                        label = "Press for tutorial"),
             class = "dropdown"),
@@ -80,7 +77,7 @@ ui <- dashboardPage(
       
       ), # sidebarMenu
       data.step = 1,
-      data.intro = "Use this sidebar to navigate around the website."
+      data.intro = "Use this sidebar to navigate around the website. Press the icon of the three lines in the top-left to access this."
     ) #introBox
   ), #dashboardSidebar
   

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -43,40 +43,45 @@ ui <- dashboardPage(
     
     introjsUI(),
     useShinyjs(),
-    sidebarMenu(
-      id = "menu",
-      
-      # Overview of a DC tab
-      menuItem(
-        text = "Overview of a DC",
-        icon = icon(name = "user"),
-        tabName = "tab_dcoverview"
-      ),
-      
-      # List of DCs tab
-      menuItem(
-        text = "List of DCs",
-        icon = icon(name = "list-ul"),
-        tabName = "tab_dclist"
-      ),
-      
-      # Survey tab
-      menuItem(
-       text = "Complete our survey",
-       icon = icon(name = "edit"),
-       badgeLabel = "new",
-       badgeColor = "green",
-       tabName = "tab_survey"
-      ),
     
-      # Construction tab
-      menuItem(
-        text = "How this was made",
-        icon = icon(name = "info-circle"),
-        tabName = "tab_construction"
-      )
-    
-    ) # sidebarMenu
+    introBox(
+      sidebarMenu(
+        id = "menu",
+        
+        # Overview of a DC tab
+        menuItem(
+          text = "Overview of a DC",
+          icon = icon(name = "user"),
+          tabName = "tab_dcoverview"
+        ),
+        
+        # List of DCs tab
+        menuItem(
+          text = "List of DCs",
+          icon = icon(name = "list-ul"),
+          tabName = "tab_dclist"
+        ),
+        
+        # Survey tab
+        menuItem(
+         text = "Complete our survey",
+         icon = icon(name = "edit"),
+         badgeLabel = "new",
+         badgeColor = "green",
+         tabName = "tab_survey"
+        ),
+      
+        # Construction tab
+        menuItem(
+          text = "How this was made",
+          icon = icon(name = "info-circle"),
+          tabName = "tab_construction"
+        )
+      
+      ), # sidebarMenu
+      data.step = 1,
+      data.intro = "Use this sidebar to navigate around the website."
+    ) #introBox
   ), #dashboardSidebar
   
   # Body
@@ -97,7 +102,7 @@ ui <- dashboardPage(
           selectizeInput(inputId = "input_dropdowntext",
                       label = "請選擇或輸入選區 / Please type or select a constituency",
                       choices = sort(unique(data_master_raw$DropDownText))),
-          data.step = 1,
+          data.step = 2,
           data.intro = "This search controls the options displayed on this tab.",
           data.hint = "You can select from the dropdown or type."
         ), #introBox
@@ -109,7 +114,7 @@ ui <- dashboardPage(
             fluidRow(
               infoBoxOutput(outputId = "infobox_fb", width = NULL)
             ),
-            data.step = 3,
+            data.step = 4,
             data.intro = "This shows the DC's name and if the colour is blue, means they have a FB page.",
             data.hint = "Click on this to access their public FB page."
           ),
@@ -119,11 +124,11 @@ ui <- dashboardPage(
               infoBoxOutput(outputId = "infobox_party", width = NULL),
               infoBoxOutput(outputId = "infobox_constituency", width = NULL)
             ),
-            data.step = 4,
+            data.step = 5,
             data.intro = "These show the party and consituency of the DC selected."
           ),
           
-          data.step = 2,
+          data.step = 3,
           data.intro = "These tiles provide basic information relating to the contituency selected."
         
         ), #introBox
@@ -135,7 +140,7 @@ ui <- dashboardPage(
               uiOutput("frame") # iframe
             ) #column
           ), #fluidRow
-          data.step = 5,
+          data.step = 6,
           data.intro = "This shows the latest posts by the DC on their FB page."
         ), #introBox
         
@@ -146,7 +151,7 @@ ui <- dashboardPage(
               leafletOutput(outputId = "plot_district", width = "100%")
             ) #box
           ), #fluidRow
-          data.step = 6,
+          data.step = 7,
           data.intro = "This highlights the constituency boundaries, with your selected constituency being highlighted.",
           data.hint = "You can also use this to find the name of your constituency by selecting your region on the map."
         ) #introBox
@@ -163,7 +168,7 @@ ui <- dashboardPage(
           fluidPage(
             DTOutput(outputId = "dc_table")
           ), #fluidPage
-          data.step = 7,
+          data.step = 8,
           data.intro = "This table shows all the DCs and their associated info."
         )
         
@@ -179,7 +184,7 @@ ui <- dashboardPage(
           fluidPage(
             htmlOutput(outputId = "html_typeform")
           ), #fluidPage
-          data.step = 8,
+          data.step = 9,
           data.intro = "Don't forget to provide us with feedback. :)"
         ) #introBox
       ), #tabItem

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -14,6 +14,10 @@ ui <- dashboardPage(
   # Header
   header = dashboardHeader(
     title = "HK: District Councillors",
+    tags$li(a(href = 'https://hong-kong-districts-info.github.io/',
+              icon(name = 'globe-asia'),
+              title = 'Website'),
+            class = "dropdown"),
     tags$li(a(href = 'https://github.com/avisionh/dashboard-hkdistrictcouncillors/',
               icon("github"),
               title = "GitHub"),

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -152,9 +152,13 @@ ui <- dashboardPage(
       tabItem(
         tabName = "tab_dclist",
         
-        fluidPage(
-          DTOutput(outputId = "dc_table")
-        ) #fluidPage
+        introBox(
+          fluidPage(
+            DTOutput(outputId = "dc_table")
+          ), #fluidPage
+          data.step = 7,
+          data.intro = "This table shows all the DCs and their associated info."
+        )
         
       ), #tabItem
       
@@ -164,9 +168,13 @@ ui <- dashboardPage(
       tabItem(
         tabName = "tab_survey",
         
-        fluidPage(
-          htmlOutput(outputId = "html_typeform")
-        ) #fluidPage
+        introBox(
+          fluidPage(
+            htmlOutput(outputId = "html_typeform")
+          ), #fluidPage
+          data.step = 8,
+          data.intro = "Don't forget to provide us with feedback. :)"
+        ) #introBox
       ), #tabItem
       
       

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -31,6 +31,8 @@ ui <- dashboardPage(
   # Sidebar
   sidebar = dashboardSidebar(
     
+    introjsUI(),
+    
     sidebarMenu(
       id = "menu",
       
@@ -60,7 +62,15 @@ ui <- dashboardPage(
         text = "How this was made",
         icon = icon(name = "info-circle"),
         tabName = "tab_construction"
+      ),
+      
+      # Tutorial tab
+      menuItem(
+        text = "How to use",
+        tabName = "tab_tutorial",
+        actionButton(inputId = "button_help", "Press for tutorial")
       )
+    
       
     ) # sidebarMenu
   ), #dashboardSidebar

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -77,7 +77,8 @@ ui <- dashboardPage(
       
       ), # sidebarMenu
       data.step = 1,
-      data.intro = "Use this sidebar to navigate around the website. Press the icon of the three lines in the top-left to access this."
+      data.intro = "Use this sidebar to navigate around the website.",
+      data.hint = "Press the icon of the three lines in the top-left to access the navigation sidebar."
     ) #introBox
   ), #dashboardSidebar
   
@@ -101,7 +102,7 @@ ui <- dashboardPage(
                       choices = sort(unique(data_master_raw$DropDownText))),
           data.step = 2,
           data.intro = "This search controls the options displayed on this tab.",
-          data.hint = "You can select from the dropdown or type."
+          data.hint = "You can select from the dropdown or type a constituency in."
         ), #introBox
         
         # nested introBox

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -66,13 +66,8 @@ ui <- dashboardPage(
         tabName = "tab_construction"
       ),
       
-      # Tutorial tab
-      menuItem(
-        text = "How to use",
-        tabName = "tab_tutorial",
-        actionButton(inputId = "button_help", "Press for tutorial")
-      )
-    
+      # Tutorial button
+      actionButton(inputId = "button_help", "Press for tutorial")
       
     ) # sidebarMenu
   ), #dashboardSidebar
@@ -90,19 +85,34 @@ ui <- dashboardPage(
       
       tabItem(
         tabName = "tab_dcoverview",
-        selectizeInput(inputId = "input_dropdowntext",
-                    label = "請選擇或輸入選區 / Please type or select a constituency",
-                    choices = sort(unique(data_master_raw$DropDownText))),
         
-
-        fluidRow(
-          infoBoxOutput(outputId = "infobox_fb", width = NULL)
-        ),
+        introBox(
+          selectizeInput(inputId = "input_dropdowntext",
+                      label = "請選擇或輸入選區 / Please type or select a constituency",
+                      choices = sort(unique(data_master_raw$DropDownText))),
+          data.step = 1,
+          data.intro = "This search controls the options displayed on this tab.",
+          data.hint = "You can select from the dropdown or type."
+        ), #introBox
         
-        fluidRow(
-          infoBoxOutput(outputId = "infobox_party_en", width = NULL),
-          infoBoxOutput(outputId = "infobox_constituency_en", width = NULL)
-        ),
+        introBox(
+          
+          introBox(
+            fluidRow(
+              infoBoxOutput(outputId = "infobox_fb", width = NULL)
+            ),
+            data.step = 3,
+            data.intro = "This shows the DC's name and if the colour is blue, means they have a FB page.",
+            data.hint = "Click on this to access their public FB page."
+          ),
+          
+          fluidRow(
+            infoBoxOutput(outputId = "infobox_party_en", width = NULL),
+            infoBoxOutput(outputId = "infobox_constituency_en", width = NULL)
+          ),
+          data.step = 2,
+          data.intro = "These tiles provide basic information relating to the contituency selected."
+        ), #introBox
         
         fluidRow(
           column(

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -111,11 +111,11 @@ ui <- dashboardPage(
           
           introBox(
             fluidRow(
-              infoBoxOutput(outputId = "infobox_fb", width = NULL)
-            ),
+              infoBoxOutput(outputId = "infobox_fb", width = NULL)) %>% 
+              helper(type = "markdown",
+                     content = "infoboxfb"),
             data.step = 4,
-            data.intro = "This shows the DC's name and if the colour is blue, means they have a FB page.",
-            data.hint = "Click on this to access their public FB page."
+            data.intro = "This shows the DC's name and if the colour is blue, means they have a FB page."
           ),
           
           introBox(
@@ -149,12 +149,13 @@ ui <- dashboardPage(
             box(
               solidHeader = TRUE, status = "success",
               leafletOutput(outputId = "plot_district", width = "100%") %>% 
-                withSpinner()
+                withSpinner() %>% 
+                helper(type = "markdown",
+                       content = "plotdistrict")
             ) #box
           ), #fluidRow
           data.step = 7,
-          data.intro = "This highlights the constituency boundaries, with your selected constituency being highlighted.",
-          data.hint = "You can also use this to find the name of your constituency by selecting your region on the map."
+          data.intro = "This highlights the constituency boundaries, with your selected constituency being highlighted."
         ) #introBox
         
       ), #tabItem

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -98,11 +98,12 @@ ui <- dashboardPage(
         
         introBox(
           selectizeInput(inputId = "input_dropdowntext",
-                      label = "請選擇或輸入選區 / Please type or select a constituency",
-                      choices = sort(unique(data_master_raw$DropDownText))),
+                         label = "請選擇或輸入選區 / Please type or select a constituency",
+                         choices = sort(unique(data_master_raw$DropDownText))) %>% 
+            helper(type = "markdown",
+                   content = "dropdowntext"),
           data.step = 2,
-          data.intro = "This search controls the options displayed on this tab.",
-          data.hint = "You can select from the dropdown or type a constituency in."
+          data.intro = "This search controls the options displayed on this tab."
         ), #introBox
         
         # nested introBox

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -15,7 +15,7 @@ ui <- dashboardPage(
   header = dashboardHeader(
     title = "HK: District Councillors",
     tags$li(actionLink(inputId = "button_help", 
-                       label = "Press for tutorial"),
+                       label = "Tutorial"),
             class = "dropdown"),
     tags$li(a(href = 'https://hong-kong-districts-info.github.io/',
               icon(name = 'globe-asia'),
@@ -134,7 +134,8 @@ ui <- dashboardPage(
           fluidRow(
             column(
               width = 3,
-              uiOutput("frame") # iframe
+              uiOutput("frame") %>% 
+                withSpinner()
             ) #column
           ), #fluidRow
           data.step = 6,
@@ -145,7 +146,8 @@ ui <- dashboardPage(
           fluidRow(
             box(
               solidHeader = TRUE, status = "success",
-              leafletOutput(outputId = "plot_district", width = "100%")
+              leafletOutput(outputId = "plot_district", width = "100%") %>% 
+                withSpinner()
             ) #box
           ), #fluidRow
           data.step = 7,
@@ -163,7 +165,8 @@ ui <- dashboardPage(
         
         introBox(
           fluidPage(
-            DTOutput(outputId = "dc_table")
+            DTOutput(outputId = "dc_table") %>% 
+              withSpinner()
           ), #fluidPage
           data.step = 8,
           data.intro = "This table shows all the DCs and their associated info."
@@ -179,7 +182,8 @@ ui <- dashboardPage(
         
         introBox(
           fluidPage(
-            htmlOutput(outputId = "html_typeform")
+            htmlOutput(outputId = "html_typeform") %>% 
+              withSpinner()
           ), #fluidPage
           data.step = 9,
           data.intro = "Don't forget to provide us with feedback. :)"

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -14,6 +14,12 @@ ui <- dashboardPage(
   # Header
   header = dashboardHeader(
     title = "HK: District Councillors",
+    tags$li(actionLink(inputId = "button_navigation",
+                       label = "Open navigation sidebar"),
+            class = "dropdown"),
+    tags$li(actionLink(inputId = "button_help", 
+                       label = "Press for tutorial"),
+            class = "dropdown"),
     tags$li(a(href = 'https://hong-kong-districts-info.github.io/',
               icon(name = 'globe-asia'),
               title = 'Website'),
@@ -37,7 +43,6 @@ ui <- dashboardPage(
     
     introjsUI(),
     useShinyjs(),
-    
     sidebarMenu(
       id = "menu",
       
@@ -69,10 +74,7 @@ ui <- dashboardPage(
         text = "How this was made",
         icon = icon(name = "info-circle"),
         tabName = "tab_construction"
-      ),
-    
-      # Tutorial button
-      actionButton(inputId = "button_help", "Press for tutorial")
+      )
     
     ) # sidebarMenu
   ), #dashboardSidebar

--- a/inst/app/ui.R
+++ b/inst/app/ui.R
@@ -54,6 +54,8 @@ ui <- dashboardPage(
       menuItem(
        text = "Complete our survey",
        icon = icon(name = "edit"),
+       badgeLabel = "new",
+       badgeColor = "green",
        tabName = "tab_survey"
       ),
       

--- a/renv.lock
+++ b/renv.lock
@@ -646,12 +646,26 @@
       "Repository": "CRAN",
       "Hash": "f895dafd39733c4a70d425f605a832e7"
     },
+    "shinycssloaders": {
+      "Package": "shinycssloaders",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f39bb3c44a9b496723ec7e86f9a771d8"
+    },
     "shinydashboard": {
       "Package": "shinydashboard",
       "Version": "0.7.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "133639dc106955eee4ffb8ec73edac37"
+    },
+    "shinyjs": {
+      "Package": "shinyjs",
+      "Version": "1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b40a5207b6624f6e2b8cdb50689cdb69"
     },
     "snakecase": {
       "Package": "snakecase",

--- a/renv.lock
+++ b/renv.lock
@@ -583,6 +583,13 @@
       "Repository": "CRAN",
       "Hash": "093584b944440c5cd07a696b3c8e0e4c"
     },
+    "rintrojs": {
+      "Package": "rintrojs",
+      "Version": "0.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "15a8768183fd609cee75e4789da27621"
+    },
     "rlang": {
       "Package": "rlang",
       "Version": "0.4.6",

--- a/renv.lock
+++ b/renv.lock
@@ -660,6 +660,13 @@
       "Repository": "CRAN",
       "Hash": "133639dc106955eee4ffb8ec73edac37"
     },
+    "shinyhelper": {
+      "Package": "shinyhelper",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "baef117734d5bd59373a561a15168679"
+    },
     "shinyjs": {
       "Package": "shinyjs",
       "Version": "1.1",


### PR DESCRIPTION
# Summary
This branch implements an interactive tutorial to the website. In particular, it highlights components of the website bit-by-bit for the user to be aware of, describing them at each step.

# Changes
The changes made in this PR are:
1. A button on the sidebar which does what it says on the tin, *Press for tutorial*
1. Step-by-step tutorial that goes through the pages.
1. Pop-up markdown in the app to provide tips on certain parts.
1. Dynamic minimising of the sidebar when the tutorial starts up.
    + This is so that it does not look messy on mobile.
1. Add loading spinners so user knows there are things that should be in parts of the website.
1. Removed tooltips on the tiles.
     + This is because the tutorial should cover this.

***

# Check
- [x] The interactive tutorial is clear and teaches people about the components of the website.
- [x] Works well on desktop and mobile.
- [x] The travis.ci and R CMD checks pass.

***

## Note
This "fixes #28"
